### PR TITLE
added funcitonality for input-number questions

### DIFF
--- a/khanacademy_revealer.user.js
+++ b/khanacademy_revealer.user.js
@@ -101,6 +101,8 @@ let item, question;
                         switch (widgetName.split(" ")[0]) {
                             case "numeric-input":
                                 return freeResponseAnswerFrom(question).log();
+                            case "input-number":
+                                return freeResponseAnswerFrom(question).log();
                             case "radio":
                                 return multipleChoiceAnswerFrom(question).log();
                             case "expression":
@@ -130,6 +132,8 @@ let item, question;
                         return answer.value;
                     }
                 });
+            } else if (widget.options?.inexact == false) {
+                return widget.options.value;
             }
         }).flat().filter((val) => { return val !== undefined; });
 


### PR DESCRIPTION
Noticed that the revealer wouldn't display answers for questions that contained input-number widgets, only numeric-input widgets. Answers are also stored differently for input-number widgets so I added functionality for them too. Should probably be tested more, I only ran it on questions with exact answers.